### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
全ファイルの改行コードを LF に正規化するやつです。
他の改行コードを使用する必要性があるファイルが生まれたら、設定を追記してください。