### PR TITLE
add rust-analyzer to recommendations extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
-    "editorconfig.editorconfig"
+    "editorconfig.editorconfig",
+    "rust-lang.rust-analyzer"
   ]
 }


### PR DESCRIPTION
              どうせならrust-analyzerも入れてしまってよい気がするのですが，いかがでしょう．
              (別PRのほうがいいかもしれませんね)

_Originally posted by @femshima in https://github.com/jpreprocess/jpreprocess/pull/50#discussion_r1212595866_
            