### PR TITLE
fix renovate schedule for github-actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,7 +45,7 @@
         "github-actions"
       ],
       "schedule": [
-        "every weekend on the 1st through 7th day of the month"
+        "on Sat on the last day of the month also every weekend on the 1st through 6th day of the month"
       ]
     }
   ]


### PR DESCRIPTION
必ず連続した土日に行われるようにした

ついたちが日曜日だった場合に １日と７日にスケジュールされるというのはなんだか気持ち悪いので…