### PR TITLE
Stop using unicode-jp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,6 @@ dependencies = [
  "lindera-dictionary",
  "lindera-tokenizer",
  "phf",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,29 +10,11 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
-dependencies = [
- "memchr 0.1.11",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
- "memchr 2.6.3",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi 0.3.9",
+ "memchr",
 ]
 
 [[package]]
@@ -90,17 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,22 +124,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
- "yaml-rust",
-]
-
-[[package]]
-name = "clap"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
@@ -186,7 +141,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.10.0",
+ "strsim",
 ]
 
 [[package]]
@@ -283,7 +238,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
- "memchr 2.6.3",
+ "memchr",
 ]
 
 [[package]]
@@ -383,7 +338,7 @@ dependencies = [
  "humantime",
  "is-terminal",
  "log",
- "regex 1.9.5",
+ "regex",
  "termcolor",
 ]
 
@@ -453,15 +408,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -523,9 +469,8 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 name = "jpreprocess"
 version = "0.4.0"
 dependencies = [
- "aho-corasick 1.0.1",
  "anyhow",
- "clap 4.4.2",
+ "clap",
  "jpreprocess-core",
  "jpreprocess-dictionary",
  "jpreprocess-dictionary-builder",
@@ -535,20 +480,20 @@ dependencies = [
  "lindera-core",
  "lindera-dictionary",
  "lindera-tokenizer",
- "once_cell",
- "unicode-jp",
+ "phf",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "jpreprocess-core"
 version = "0.4.0"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick",
  "anyhow",
  "bincode",
  "lindera-tokenizer",
  "once_cell",
- "regex 1.9.5",
+ "regex",
  "serde",
  "thiserror",
 ]
@@ -613,7 +558,7 @@ dependencies = [
 name = "jpreprocess-njd"
 version = "0.4.0"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick",
  "jpreprocess-core",
  "jpreprocess-dictionary",
  "jpreprocess-window",
@@ -634,22 +579,6 @@ checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -831,15 +760,6 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
@@ -992,27 +912,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
-dependencies = [
- "aho-corasick 0.5.3",
- "memchr 0.1.11",
- "regex-syntax 0.3.9",
- "thread_local",
- "utf8-ranges",
-]
-
-[[package]]
-name = "regex"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
- "aho-corasick 1.0.1",
- "memchr 2.6.3",
+ "aho-corasick",
+ "memchr",
  "regex-automata",
- "regex-syntax 0.7.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1021,16 +928,10 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
- "aho-corasick 1.0.1",
- "memchr 2.6.3",
- "regex-syntax 0.7.5",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 
 [[package]]
 name = "regex-syntax"
@@ -1050,7 +951,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1156,12 +1057,6 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -1209,15 +1104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,25 +1121,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.28",
-]
-
-[[package]]
-name = "thread-id"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-dependencies = [
- "kernel32-sys",
- "libc",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
-dependencies = [
- "thread-id",
 ]
 
 [[package]]
@@ -1284,17 +1151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
-name = "unicode-jp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46edb7c8d7351ff403b9679b217dcc1df82328fd9f7e811274ac1d90cff2e81f"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "regex 0.1.80",
-]
-
-[[package]]
 name = "unicode-normalization"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,12 +1158,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "untrusted"
@@ -1342,28 +1192,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8-ranges"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1371,24 +1209,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.105",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1396,22 +1234,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.105",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
@@ -1434,12 +1272,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -1447,12 +1279,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1466,7 +1292,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1621,9 +1447,3 @@ name = "yada"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d12cb7a57bbf2ab670ed9545bae3648048547f9039279a89ce000208e585c1"
-
-[[package]]
-name = "yaml-rust"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"

--- a/crates/jpreprocess/Cargo.toml
+++ b/crates/jpreprocess/Cargo.toml
@@ -38,8 +38,6 @@ jpreprocess-jpcommon = { version = "0.4.0", path="../jpreprocess-jpcommon" }
 jpreprocess-dictionary = { version = "0.4.0", path="../jpreprocess-dictionary" }
 jpreprocess-dictionary-builder = { version = "0.4.0", path="../jpreprocess-dictionary-builder" }
 
-wasm-bindgen = "0.2.87"
-
 jpreprocess-naist-jdic = { version = "0.4.0", path="../jpreprocess-naist-jdic", optional = true }
 
 clap = { version = "4.4.2", features = ["derive"], optional = true }

--- a/crates/jpreprocess/Cargo.toml
+++ b/crates/jpreprocess/Cargo.toml
@@ -29,16 +29,16 @@ lindera-core = { version = "0.27" }
 lindera-tokenizer = { version = "0.27" }
 lindera-dictionary = { version = "0.27" }
 
-aho-corasick = "1.0"
-once_cell = "1.18.0"
+phf = { version = "0.11", features = ["macros"] }
 anyhow = "1.0.75"
-unicode-jp = "0.4.0"
 
 jpreprocess-core = { version = "0.4.0", path="../jpreprocess-core" }
 jpreprocess-njd = { version = "0.4.0", path="../jpreprocess-njd" }
 jpreprocess-jpcommon = { version = "0.4.0", path="../jpreprocess-jpcommon" }
 jpreprocess-dictionary = { version = "0.4.0", path="../jpreprocess-dictionary" }
 jpreprocess-dictionary-builder = { version = "0.4.0", path="../jpreprocess-dictionary-builder" }
+
+wasm-bindgen = "0.2.87"
 
 jpreprocess-naist-jdic = { version = "0.4.0", path="../jpreprocess-naist-jdic", optional = true }
 

--- a/crates/jpreprocess/src/normalize_text.rs
+++ b/crates/jpreprocess/src/normalize_text.rs
@@ -1,18 +1,199 @@
+use phf::{phf_map, phf_set, Map, Set};
+
 /// Normalize input text
 pub fn normalize_text_for_naist_jdic(input_text: &str) -> String {
-    let yen_space = kana::yen2wide(&kana::space2wide(input_text).replace('\\', "\u{00A5}"));
-    let kana = kana::vsmark2full(&kana::combine(&kana::half2full(&yen_space)))
-        .replace(['\u{309B}', '\u{309C}'], "");
-    let kana_ascii = kana::ascii2wide(
-        &kana
-            .replace('-', "\u{2212}") // − U+2212 MINUS SIGN
-            .replace('~', "\u{301C}") // 〜 U+301C WAVE DASH
-            .replace('`', "\u{2018}") // ‘ U+2018 LEFT SINGLE QUOTATION MARK
-            .replace('\"', "\u{201D}") // ” U+201D RIGHT DOUBLE QUOTATION MARK
-            .replace('\'', "\u{2019}"), // ’ U+2019 RIGHT SINGLE QUOTATION MARK
-    );
-    kana::space2wide(&kana_ascii)
+    let (mut s, c) = input_text
+        .chars()
+        .map(|c| {
+            if let Some(replacement) = HALFWIDTH.get(&c) {
+                replacement.clone()
+            } else if '\u{0020}' < c && c < '\u{007f}' {
+                char::from_u32((c as u32) + 0xfee0).unwrap()
+            } else {
+                c
+            }
+        })
+        .fold(
+            (String::with_capacity(input_text.len()), None),
+            |(mut acc, prev), curr| {
+                let semivoiced = SEMIVOICED_SOUND_MARK.contains(&curr);
+                let voiced = VOICED_SOUND_MARK.contains(&curr);
+
+                let combined = if semivoiced {
+                    prev.and_then(|p| SEMIVOICED.get(&p))
+                } else if voiced {
+                    prev.and_then(|p| VOICED.get(&p))
+                } else {
+                    None
+                };
+
+                if let Some(combined) = combined {
+                    acc.push(*combined);
+                } else if let Some(prev_char) = prev {
+                    acc.push(prev_char);
+                }
+
+                if semivoiced || voiced {
+                    (acc, None)
+                } else {
+                    (acc, Some(curr))
+                }
+            },
+        );
+
+    if let Some(c) = c {
+        s.push(c);
+    }
+    s
 }
+
+const HALFWIDTH: Map<char, char> = phf_map! {
+    // Symbols
+    ' ' => '\u{3000}', // 　 U+3000 Ideographic Space
+    '\u{a5}' => '\u{FFE5}', // ￥ U+FFE5 Fullwidth Yen Sign
+    '\\' => '\u{FFE5}', // ￥ U+FFE5 Fullwidth Yen Sign
+    '-' => '\u{2212}', // − U+2212 MINUS SIGN
+    '~' => '\u{301C}', // 〜 U+301C WAVE DASH
+    '`' => '\u{2018}', // ‘ U+2018 LEFT SINGLE QUOTATION MARK
+    '\"' => '\u{201D}', // ” U+201D RIGHT DOUBLE QUOTATION MARK
+    '\'' => '\u{2019}', // ’ U+2019 RIGHT SINGLE QUOTATION MARK
+    // Halfwidth japanese symbols
+    '\u{FF61}' => '\u{3002}', // 。 U+3002 Ideographic Full Stop
+    '\u{FF62}' => '\u{300C}', // 「 U+300C Left Corner Bracket Ideographic Full Stop
+    '\u{FF63}' => '\u{300D}', // 」 U+300D Right Corner Bracket
+    '\u{FF64}' => '\u{3001}', // 、 U+3001 Ideographic Comma
+    '\u{FF65}' => '\u{30FB}', // ・ U+30FB Katakana Middle Dot
+    // Katakana
+    'ｦ' => 'ヲ',
+    'ｧ' => 'ァ',
+    'ｨ' => 'ィ',
+    'ｩ' => 'ゥ',
+    'ｪ' => 'ェ',
+    'ｫ' => 'ォ',
+    'ｬ' => 'ャ',
+    'ｭ' => 'ュ',
+    'ｮ' => 'ョ',
+    'ｯ' => 'ッ',
+    'ｰ' => 'ー',
+    'ｱ' => 'ア',
+    'ｲ' => 'イ',
+    'ｳ' => 'ウ',
+    'ｴ' => 'エ',
+    'ｵ' => 'オ',
+    'ｶ' => 'カ',
+    'ｷ' => 'キ',
+    'ｸ' => 'ク',
+    'ｹ' => 'ケ',
+    'ｺ' => 'コ',
+    'ｻ' => 'サ',
+    'ｼ' => 'シ',
+    'ｽ' => 'ス',
+    'ｾ' => 'セ',
+    'ｿ' => 'ソ',
+    'ﾀ' => 'タ',
+    'ﾁ' => 'チ',
+    'ﾂ' => 'ツ',
+    'ﾃ' => 'テ',
+    'ﾄ' => 'ト',
+    'ﾅ' => 'ナ',
+    'ﾆ' => 'ニ',
+    'ﾇ' => 'ヌ',
+    'ﾈ' => 'ネ',
+    'ﾉ' => 'ノ',
+    'ﾊ' => 'ハ',
+    'ﾋ' => 'ヒ',
+    'ﾌ' => 'フ',
+    'ﾍ' => 'ヘ',
+    'ﾎ' => 'ホ',
+    'ﾏ' => 'マ',
+    'ﾐ' => 'ミ',
+    'ﾑ' => 'ム',
+    'ﾒ' => 'メ',
+    'ﾓ' => 'モ',
+    'ﾔ' => 'ヤ',
+    'ﾕ' => 'ユ',
+    'ﾖ' => 'ヨ',
+    'ﾗ' => 'ラ',
+    'ﾘ' => 'リ',
+    'ﾙ' => 'ル',
+    'ﾚ' => 'レ',
+    'ﾛ' => 'ロ',
+    'ﾜ' => 'ワ',
+    'ﾝ' => 'ン',
+};
+
+const SEMIVOICED_SOUND_MARK: Set<char> = phf_set! {
+    '\u{309A}', // U+309A Combining Katakana-Hiragana Semi-Voiced Sound Mark
+    '\u{309C}', // U+309C Katakana-Hiragana Semi-Voiced Sound Mark
+    '\u{FF9F}', // U+FF9F Halfwidth Katakana Semi-Voiced Sound Mark
+};
+const SEMIVOICED: Map<char, char> = phf_map! {
+    'ハ' => 'パ',
+    'ヒ' => 'ピ',
+    'フ' => 'プ',
+    'ヘ' => 'ペ',
+    'ホ' => 'ポ',
+    'は' => 'ぱ',
+    'ひ' => 'ぴ',
+    'ふ' => 'ぷ',
+    'へ' => 'ぺ',
+    'ほ' => 'ぽ',
+};
+
+const VOICED_SOUND_MARK: Set<char> = phf_set! {
+    '\u{3099}', // U+3099 Combining Katakana-Hiragana Voiced Sound Mark
+    '\u{309B}', // U+309B Katakana-Hiragana Voiced Sound Mark
+    '\u{FF9E}', // U+FF9E Halfwidth Katakana Voiced Sound Mark
+};
+const VOICED: Map<char, char> = phf_map! {
+    'カ' => 'ガ',
+    'キ' => 'ギ',
+    'ク' => 'グ',
+    'ケ' => 'ゲ',
+    'コ' => 'ゴ',
+    'サ' => 'ザ',
+    'シ' => 'ジ',
+    'ス' => 'ズ',
+    'セ' => 'ゼ',
+    'ソ' => 'ゾ',
+    'タ' => 'ダ',
+    'チ' => 'ヂ',
+    'ツ' => 'ヅ',
+    'テ' => 'デ',
+    'ト' => 'ド',
+    'ハ' => 'バ',
+    'ヒ' => 'ビ',
+    'フ' => 'ブ',
+    'ヘ' => 'ベ',
+    'ホ' => 'ボ',
+    'ウ' => 'ヴ',
+    'ワ' => 'ヷ',
+    'ヰ' => 'ヸ',
+    'ヱ' => 'ヹ',
+    'ヲ' => 'ヺ',
+    'ヽ' => 'ヾ',
+    'か' => 'が',
+    'き' => 'ぎ',
+    'く' => 'ぐ',
+    'け' => 'げ',
+    'こ' => 'ご',
+    'さ' => 'ざ',
+    'し' => 'じ',
+    'す' => 'ず',
+    'せ' => 'ぜ',
+    'そ' => 'ぞ',
+    'た' => 'だ',
+    'ち' => 'ぢ',
+    'つ' => 'づ',
+    'て' => 'で',
+    'と' => 'ど',
+    'は' => 'ば',
+    'ひ' => 'び',
+    'ふ' => 'ぶ',
+    'へ' => 'べ',
+    'ほ' => 'ぼ',
+    'う' => 'ゔ',
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/jpreprocess/src/normalize_text.rs
+++ b/crates/jpreprocess/src/normalize_text.rs
@@ -6,7 +6,7 @@ pub fn normalize_text_for_naist_jdic(input_text: &str) -> String {
         .chars()
         .map(|c| {
             if let Some(replacement) = HALFWIDTH.get(&c) {
-                replacement.clone()
+                *replacement
             } else if '\u{0020}' < c && c < '\u{007f}' {
                 char::from_u32((c as u32) + 0xfee0).unwrap()
             } else {


### PR DESCRIPTION
unicode-jp is unmaintained and using older version of regex.
This results in build error in wasm32 environment.

Therefore, I decided to remove unicode-jp and write it on my own.
