### PR TITLE
Remove `dyn` from structs

### DIFF
--- a/crates/jpreprocess-dictionary/src/default.rs
+++ b/crates/jpreprocess-dictionary/src/default.rs
@@ -11,8 +11,8 @@ use super::{
 /// Holds the dictionary mode of both system and user dictionary,
 /// and routes Token to either dictionary.
 pub struct DefaultFetcher {
-    pub system: WordDictionaryMode,
-    pub user: Option<WordDictionaryMode>,
+    system: WordDictionaryMode,
+    user: Option<WordDictionaryMode>,
 }
 
 impl DefaultFetcher {

--- a/crates/jpreprocess-dictionary/src/default.rs
+++ b/crates/jpreprocess-dictionary/src/default.rs
@@ -6,29 +6,38 @@ use super::{
     DictionaryFetcher, DictionarySerializer, DictionaryStore,
 };
 
-pub struct WordDictionaryConfig {
-    pub system: Box<dyn DictionarySerializer>,
-    pub user: Option<Box<dyn DictionarySerializer>>,
+pub struct DefaultFetcher {
+    pub system: WordDictionaryMode,
+    pub user: Option<WordDictionaryMode>,
 }
 
-impl WordDictionaryConfig {
+impl DefaultFetcher {
     pub fn new(system: WordDictionaryMode, user: Option<WordDictionaryMode>) -> Self {
+        Self { system, user }
+    }
+
+    pub fn from_dictionaries<System, User>(system: &System, user: Option<&User>) -> Self
+    where
+        System: for<'a> DictionaryStore<'a>,
+        User: for<'a> DictionaryStore<'a>,
+    {
         Self {
-            system: system.into_serializer(),
-            user: user.map(|user| user.into_serializer() as Box<dyn DictionarySerializer>),
+            system: WordDictionaryMode::from_metadata(system.identifier()),
+            user: user.map(|user| WordDictionaryMode::from_metadata(user.identifier())),
         }
     }
 }
 
-impl DictionaryFetcher for WordDictionaryConfig {
+impl DictionaryFetcher for DefaultFetcher {
     fn get_word(&self, token: &Token) -> JPreprocessResult<WordEntry> {
         if token.word_id.is_unknown() {
             Ok(WordEntry::default())
         } else if token.word_id.is_system() {
             self.system
+                .into_serializer()
                 .deserialize(token.dictionary.get_bytes(token.word_id.0)?)
         } else if let Some(ref user_dict) = self.user {
-            user_dict.deserialize(
+            user_dict.into_serializer().deserialize(
                 token
                     .user_dictionary
                     .ok_or(
@@ -52,6 +61,7 @@ impl DictionaryFetcher for WordDictionaryConfig {
 pub enum WordDictionaryMode {
     Lindera,
     JPreprocess,
+    JPreprocessLegacyV051,
 }
 
 impl WordDictionaryMode {
@@ -59,6 +69,30 @@ impl WordDictionaryMode {
         match self {
             Self::Lindera => Box::new(LinderaSerializer),
             Self::JPreprocess => Box::new(JPreprocessSerializer),
+            Self::JPreprocessLegacyV051 => {
+                Box::new(crate::serializer::jpreprocess::legacy_0_5_1::JPreprocessSerializer)
+            }
         }
+    }
+
+    pub fn from_metadata(metadata: Option<String>) -> Self {
+        if let Some(metadata) = metadata {
+            let segments: Vec<&str> = metadata.split(' ').collect();
+            match *segments.as_slice() {
+                ["JPreprocess", "v0.1.0" | "v0.1.1" | "v0.2.0"] => {
+                    panic!(concat!(
+                        "Incompatible Dictionary! ",
+                        "Dictionaries built with JPreprocess versions before v0.3.0 ",
+                        "are not compatible with this version of JPreprocess."
+                    ))
+                }
+                ["JPreprocess", "v0.3.0" | "v0.4.0" | "v0.5.0" | "v0.5.1"] => {
+                    return Self::JPreprocessLegacyV051
+                }
+                ["JPreprocess", ..] => return Self::JPreprocess,
+                _ => (),
+            }
+        }
+        Self::Lindera
     }
 }

--- a/crates/jpreprocess-dictionary/src/default.rs
+++ b/crates/jpreprocess-dictionary/src/default.rs
@@ -6,6 +6,10 @@ use super::{
     DictionaryFetcher, DictionarySerializer, DictionaryStore,
 };
 
+/// Default [`DictionaryFetcher`] of JPreprocess.
+///
+/// Holds the dictionary mode of both system and user dictionary,
+/// and routes Token to either dictionary.
 pub struct DefaultFetcher {
     pub system: WordDictionaryMode,
     pub user: Option<WordDictionaryMode>,
@@ -57,6 +61,7 @@ impl DictionaryFetcher for DefaultFetcher {
     }
 }
 
+/// Dictionary serialization/deserialization mode.
 #[derive(Clone, Copy, Debug)]
 pub enum WordDictionaryMode {
     Lindera,

--- a/crates/jpreprocess-dictionary/src/lib.rs
+++ b/crates/jpreprocess-dictionary/src/lib.rs
@@ -2,7 +2,8 @@ use jpreprocess_core::{word_entry::WordEntry, JPreprocessResult};
 use lindera_core::LinderaResult;
 use lindera_tokenizer::token::Token;
 
-pub mod fetcher;
+pub mod default;
+
 pub mod serializer;
 pub mod store;
 
@@ -27,7 +28,6 @@ where
 pub trait DictionaryStore<'a> {
     fn get_bytes(&'a self, id: u32) -> JPreprocessResult<&'a [u8]>;
     fn identifier(&self) -> Option<String>;
-    fn serlializer_hint(&self) -> Box<dyn DictionarySerializer>;
 }
 impl<'a, T> DictionaryStore<'a> for T
 where
@@ -38,9 +38,6 @@ where
     }
     fn identifier(&self) -> Option<String> {
         self.as_ref().identifier()
-    }
-    fn serlializer_hint(&self) -> Box<dyn DictionarySerializer> {
-        self.as_ref().serlializer_hint()
     }
 }
 

--- a/crates/jpreprocess-dictionary/src/lib.rs
+++ b/crates/jpreprocess-dictionary/src/lib.rs
@@ -7,6 +7,7 @@ pub mod default;
 pub mod serializer;
 pub mod store;
 
+/// Fetch [`WordEntry`] corresponding to the given [`Token`].
 pub trait DictionaryFetcher {
     fn get_word(&self, token: &Token) -> JPreprocessResult<WordEntry>;
     fn get_word_vectored(&self, tokens: &[Token]) -> JPreprocessResult<Vec<WordEntry>> {
@@ -25,8 +26,11 @@ where
     }
 }
 
+/// Dictionary storage trait.
 pub trait DictionaryStore<'a> {
+    /// Get binary data for the word with the given id.
     fn get_bytes(&'a self, id: u32) -> JPreprocessResult<&'a [u8]>;
+    /// Get the identifier (e.g. the variant or version of this dictionary).
     fn identifier(&self) -> Option<String>;
 }
 impl<'a, T> DictionaryStore<'a> for T

--- a/crates/jpreprocess/src/bin/dict_tools/dict_query.rs
+++ b/crates/jpreprocess/src/bin/dict_tools/dict_query.rs
@@ -1,5 +1,5 @@
 use jpreprocess_core::JPreprocessResult;
-use jpreprocess_dictionary::DictionaryStore;
+use jpreprocess_dictionary::{default::WordDictionaryMode, DictionaryStore};
 use lindera_core::{
     dictionary::{Dictionary, UserDictionary},
     prefix_dict::PrefixDict,
@@ -17,6 +17,12 @@ impl QueryDict {
             Self::User(dict) => (&dict.dict, &dict.words_idx_data, &dict.words_data),
         }
     }
+    pub fn mode(&self) -> WordDictionaryMode {
+        match self {
+            Self::System(dict) => WordDictionaryMode::from_metadata(dict.identifier()),
+            Self::User(dict) => WordDictionaryMode::from_metadata(dict.identifier()),
+        }
+    }
 }
 
 impl<'a> DictionaryStore<'a> for QueryDict {
@@ -30,12 +36,6 @@ impl<'a> DictionaryStore<'a> for QueryDict {
         match self {
             Self::System(dict) => dict.identifier(),
             Self::User(dict) => dict.identifier(),
-        }
-    }
-    fn serlializer_hint(&self) -> Box<dyn jpreprocess_dictionary::DictionarySerializer> {
-        match self {
-            Self::System(dict) => dict.serlializer_hint(),
-            Self::User(dict) => dict.serlializer_hint(),
         }
     }
 }

--- a/crates/jpreprocess/src/bin/dict_tools/main.rs
+++ b/crates/jpreprocess/src/bin/dict_tools/main.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use jpreprocess::SystemDictionaryConfig;
 use jpreprocess_core::error::JPreprocessErrorKind;
-use jpreprocess_dictionary::{fetcher::WordDictionaryMode, DictionaryStore};
+use jpreprocess_dictionary::{default::WordDictionaryMode, DictionaryStore};
 use jpreprocess_dictionary_builder::{ipadic_builder::IpadicBuilder, to_csv::dict_to_csv};
 
 use lindera_core::dictionary_builder::DictionaryBuilder;
@@ -117,7 +117,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                             return Ok(());
                         }
                     };
-                    let message = dict.serlializer_hint().deserialize_debug(word_bin);
+                    let message = dict.mode().into_serializer().deserialize_debug(word_bin);
                     println!("{}", message);
                 }
             }

--- a/crates/jpreprocess/src/bin/jpreprocess.rs
+++ b/crates/jpreprocess/src/bin/jpreprocess.rs
@@ -45,14 +45,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         SystemDictionaryConfig::Bundled(kind::JPreprocessDictionaryKind::NaistJdic)
     };
 
-    let user_dictionary = if let Some(user_dict) = cli.user_dictionary {
-        Some(UserDictionaryConfig {
-            path: user_dict,
-            kind: Some(lindera_dictionary::DictionaryKind::IPADIC),
-        })
-    } else {
-        None
-    };
+    let user_dictionary = cli.user_dictionary.map(|user_dict| UserDictionaryConfig {
+        path: user_dict,
+        kind: Some(lindera_dictionary::DictionaryKind::IPADIC),
+    });
 
     let jpreprocess = JPreprocess::from_config(JPreprocessConfig {
         dictionary,

--- a/crates/jpreprocess/src/lib.rs
+++ b/crates/jpreprocess/src/lib.rs
@@ -49,7 +49,7 @@ pub use jpreprocess_core::error;
 pub use jpreprocess_njd::NJD;
 
 use jpreprocess_core::*;
-use jpreprocess_dictionary::{fetcher::WordDictionaryConfig, DictionaryFetcher, DictionaryStore};
+use jpreprocess_dictionary::{default::DefaultFetcher, DictionaryFetcher};
 use lindera_core::dictionary::{Dictionary, UserDictionary};
 use lindera_dictionary::{load_user_dictionary, UserDictionaryConfig};
 use lindera_tokenizer::tokenizer::Tokenizer;
@@ -126,12 +126,8 @@ impl JPreprocess {
         dictionary: Dictionary,
         user_dictionary: Option<UserDictionary>,
     ) -> Self {
-        let dictionary_fetcher = WordDictionaryConfig {
-            system: dictionary.serlializer_hint(),
-            user: user_dictionary
-                .as_ref()
-                .map(DictionaryStore::serlializer_hint),
-        };
+        let dictionary_fetcher =
+            DefaultFetcher::from_dictionaries(&dictionary, user_dictionary.as_ref());
 
         Self::with_dictionary_fetcher(dictionary, user_dictionary, Box::new(dictionary_fetcher))
     }

--- a/crates/jpreprocess/src/lib.rs
+++ b/crates/jpreprocess/src/lib.rs
@@ -152,16 +152,6 @@ impl JPreprocess {
         }
     }
 
-    /// Alias of [`with_dictionaries`].
-    ///
-    /// Note: `new` before v0.2.0 has moved to `from_config`.
-    ///
-    /// [`with_dictionaries`]: #method.with_dictionaries
-    #[deprecated(since = "0.5.0", note = "please use `with_dictionaries` instead")]
-    pub fn new(dictionary: Dictionary, user_dictionary: Option<UserDictionary>) -> Self {
-        Self::with_dictionaries(dictionary, user_dictionary)
-    }
-
     /// Tokenize input text and return NJD.
     ///
     /// Useful for customizing text processing.

--- a/crates/jpreprocess/src/lib.rs
+++ b/crates/jpreprocess/src/lib.rs
@@ -130,18 +130,16 @@ impl JPreprocess<DefaultFetcher> {
         let dictionary_fetcher =
             DefaultFetcher::from_dictionaries(&dictionary, user_dictionary.as_ref());
 
-        Self::with_dictionary_fetcher(dictionary, user_dictionary, dictionary_fetcher)
+        Self::with_dictionary_fetcher(dictionary_fetcher, dictionary, user_dictionary)
     }
 }
 
 impl<F: DictionaryFetcher> JPreprocess<F> {
     /// Creates JPreprocess with provided dictionary fetcher.
-    ///
-    /// Note: I'm not sure if this is useful for someone. If you need this, please create an issue.
-    fn with_dictionary_fetcher(
+    pub fn with_dictionary_fetcher(
+        dictionary_fetcher: F,
         dictionary: Dictionary,
         user_dictionary: Option<UserDictionary>,
-        dictionary_fetcher: F,
     ) -> Self {
         let tokenizer = Tokenizer::new(
             dictionary,

--- a/examples/example-wasm/src/lib.rs
+++ b/examples/example-wasm/src/lib.rs
@@ -103,7 +103,7 @@ impl From<IVecString> for Vec<String> {
 
 #[wasm_bindgen]
 pub struct JPreprocess {
-    inner: jpreprocess::JPreprocess,
+    inner: jpreprocess::JPreprocess<jpreprocess::DefaultFetcher>,
 }
 #[wasm_bindgen]
 impl JPreprocess {


### PR DESCRIPTION
ref: #221 

Remove `dyn` from struct definition as possible, and add support for multithreading.

## Breaking Changes

- `WordDictionaryConfig` was removed (in other words: renamed to `DefaultFetcher` and heavily modified)
- `DictionaryStore` no longer has `serlializer_hint` function
- `JPreprocess` struct requires type parameter `F`
- `JPreprocess`'s deprecated `new` function is finally removed