### PR TITLE
supress empty-doc-comment by adding doc comment

### DIFF
--- a/examples/example-wasm/src/lib.rs
+++ b/examples/example-wasm/src/lib.rs
@@ -74,10 +74,13 @@ impl TryFrom<JsUserDictionary> for lindera_core::dictionary::UserDictionary {
 
 #[wasm_bindgen]
 extern "C" {
+    /// Dictionary data
     #[wasm_bindgen(typescript_type = "Dictionary")]
     pub type IDictionary;
+    /// User dictionary data
     #[wasm_bindgen(typescript_type = "UserDictionary")]
     pub type IUserDictionary;
+    /// Array of strings
     #[wasm_bindgen(typescript_type = "string[]")]
     pub type IVecString;
 }


### PR DESCRIPTION
出力されるd.tsには書かれないようで，何のために書いているのかはよくわからないが，clippyが文句をいうので書いておく．