### PR TITLE
chore: write the cause of space difference

### DIFF
--- a/tests/src/open_jtalk.rs
+++ b/tests/src/open_jtalk.rs
@@ -77,7 +77,7 @@ fn test_one(input_text: &'static str) {
 
         if node_ans.get_pos() == &POS::Kigou(Kigou::Space) {
             // Pass the difference introduced between Lindera 0.42.0 and 1.3.0
-            // TODO: Find the cause
+            // This is because Lindera dictionary builder trims spaces from v1.0.0.
             assert_eq!(node.get_string(), "\u{3000}");
             assert_eq!(node.get_pos(), &POS::Kigou(Kigou::None));
             continue;


### PR DESCRIPTION
Ref: #451

Lindera 1.0.0より，辞書のビルド時に空白文字が削除される挙動が追加された．

https://github.com/lindera/lindera/blob/ebe1cb52756b4fb788f78cde1f90cc9bb6767ed8/lindera-dictionary/src/builder/prefix_dictionary.rs#L239

これにより，辞書のdouble arrayにnaist-jdic由来の\u{3000}が入らず，パース後に
```
\u{3000},記号,空白,*,*,*,*,\u{3000},、,、,0/0,*,0
```
ではなく
```
\u{3000},記号,*,*,*,*,*,\u{3000},、,、,0/0,*,0
```
になる．

現在`Kigou(None)`を使っている場所はないので，挙動上の違いはないと考えられるが，記録として残しておく．