### PR TITLE
fix: change default pos to Meishi

### DIFF
--- a/crates/jpreprocess-core/src/word_details.rs
+++ b/crates/jpreprocess-core/src/word_details.rs
@@ -3,11 +3,16 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    accent_rule::ChainRules, cform::CForm, ctype::CType, pos::POS, pronunciation::Pronunciation,
-    word_line::WordDetailsLine, JPreprocessResult,
+    accent_rule::ChainRules,
+    cform::CForm,
+    ctype::CType,
+    pos::{Meishi, POS},
+    pronunciation::Pronunciation,
+    word_line::WordDetailsLine,
+    JPreprocessResult,
 };
 
-#[derive(Clone, PartialEq, Serialize, Deserialize, Debug, Default)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
 pub struct WordDetails {
     pub pos: POS,
     pub ctype: CType,
@@ -16,6 +21,20 @@ pub struct WordDetails {
     pub pron: Pronunciation,
     pub chain_rule: ChainRules,
     pub chain_flag: Option<bool>,
+}
+
+impl Default for WordDetails {
+    fn default() -> Self {
+        Self {
+            pos: POS::Meishi(Meishi::None),
+            ctype: CType::default(),
+            cform: CForm::default(),
+            read: None,
+            pron: Pronunciation::default(),
+            chain_rule: ChainRules::default(),
+            chain_flag: None,
+        }
+    }
 }
 
 impl WordDetails {

--- a/crates/jpreprocess-core/src/word_entry.rs
+++ b/crates/jpreprocess-core/src/word_entry.rs
@@ -1,4 +1,4 @@
-use crate::{pos::*, word_details::WordDetails, word_line::WordDetailsLine, JPreprocessResult};
+use crate::{word_details::WordDetails, word_line::WordDetailsLine, JPreprocessResult};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
@@ -9,10 +9,7 @@ pub enum WordEntry {
 
 impl Default for WordEntry {
     fn default() -> Self {
-        Self::Single(WordDetails {
-            pos: POS::Meishi(Meishi::None),
-            ..Default::default()
-        })
+        Self::Single(WordDetails::default())
     }
 }
 

--- a/crates/jpreprocess-core/src/word_line.rs
+++ b/crates/jpreprocess-core/src/word_line.rs
@@ -23,7 +23,7 @@ pub struct WordDetailsLine {
 impl Default for WordDetailsLine {
     fn default() -> Self {
         Self {
-            pos: "*".to_string(),
+            pos: "名詞".to_string(),
             pos_group1: "*".to_string(),
             pos_group2: "*".to_string(),
             pos_group3: "*".to_string(),


### PR DESCRIPTION
fixes #465 

WordEntryの既存の挙動とWordDetailsLineの挙動を統一する．シンプルなユーザー辞書ではほとんど名詞であることが予想されるので，その挙動も改善すると考えられる．

なお，この変更により，シンプルなユーザー辞書をLindera側でパースするか，jpreprocess側でパースするかで挙動に違いが生じる．これについては，（deprecatedなAPIを除くと）考慮できていないのはpython APIだけのはずなので，そちらは別途検討する．